### PR TITLE
Analog Input Support

### DIFF
--- a/input.c
+++ b/input.c
@@ -72,7 +72,7 @@ static inline void process_analog(void) {
 
   // Read the top 8 bits and store in the currently-polled analog value
   _io_analog.raw[index] = ADCH;
-
+  // Invert the value if requested
   if (_io_analog.invert & (1 << index))
     _io_analog.raw[index] = 255 - _io_analog.raw[index];
 
@@ -165,7 +165,7 @@ void Input_RotaryLogicalTarget(uint8_t index, uint16_t logical_max, uint16_t log
     enc->increment16 = ((65536 / logical_max) * logical_per_rotation) / enc->max_position;
 }
 
-void Input_SetAnalogRange(uint8_t index, uint8_t trigger, uint8_t release) {
+void Input_AnalogDigitalThresholds(uint8_t index, uint8_t trigger, uint8_t release) {
   _io_analog.trigger[index] = trigger,
   _io_analog.release[index] = release;
 }

--- a/input.h
+++ b/input.h
@@ -34,6 +34,26 @@ typedef enum {
 } INPUT_PIN_INDEX;
 
 typedef enum {
+  ANALOG_F0,
+  ANALOG_F1,
+  ANALOG_F4 = 0x04,
+  ANALOG_F5,
+  ANALOG_F6,
+  ANALOG_F7,
+  ANALOG_D4 = 0x20,
+  ANALOG_D6,
+  ANALOG_D7,
+  ANALOG_B4,
+  ANALOG_B5,
+  ANALOG_B6,
+} ANALOG_PIN_INDEX;
+
+typedef enum {
+  ANALOG_NORMAL,
+  ANALOG_INVERT,
+} ANALOG_SHOULD_INVERT;
+
+typedef enum {
   INPUT_FREQ_1KHZ = 249,
   INPUT_FREQ_2KHZ = 124,
   INPUT_FREQ_4KHZ = 62,
@@ -74,6 +94,16 @@ typedef struct {
 
 typedef struct {
   uint8_t   active;
+  uint16_t  raw[12];
+  uint16_t  invert;
+  uint8_t   trigger[12];
+  uint8_t   release[12];
+  ANALOG_PIN_INDEX mask[12];
+  uint16_t digital;
+} Input_Analog_t;
+
+typedef struct {
+  uint8_t   active;
   uint16_t  data;
   uint8_t   group[16];
   uint8_t   mask[16];
@@ -85,6 +115,7 @@ typedef struct {
 } Output_Pins_t;
 
 void Input_RegisterButton(INPUT_PIN_INDEX pin);
+void Input_RegisterAnalog(ANALOG_PIN_INDEX pin, ANALOG_SHOULD_INVERT invert);
 void Input_RegisterRotary(INPUT_PIN_INDEX pin1, INPUT_PIN_INDEX pin2, uint16_t ppr, uint16_t hold);
 
 void Output_RegisterPin(INPUT_PIN_INDEX pin);
@@ -94,19 +125,25 @@ void InputOutput_Begin(INPUT_FREQUENCY freq);
 void Input_Task(void);
 void Output_Task(void);
 
-uint16_t Input_Ticks(uint16_t index);
+uint16_t Input_Ticks(uint8_t index);
 uint16_t Input_GetButtons(void);
-uint16_t Input_GetRotaryPhysicalPosition(uint16_t index);
-uint16_t Input_GetRotaryLogicalPosition(uint16_t index);
-uint16_t Input_GetRotaryMaximum(uint16_t index);
-uint16_t Input_GetRotaryDirection(uint16_t index);
+uint16_t Input_GetRotaryPhysicalPosition(uint8_t index);
+uint16_t Input_GetRotaryLogicalPosition(uint8_t index);
+uint16_t Input_GetRotaryMaximum(uint8_t index);
+uint16_t Input_GetRotaryDirection(uint8_t index);
+uint16_t Input_GetAnalog(uint8_t index);
+uint16_t Input_GetAnalogDigital(void);
 
-void Input_SetRotaryLogicalTarget(uint16_t index, uint16_t logical_max, uint16_t logical_per_rotation);
+void Input_RotaryLogicalTarget(uint8_t index, uint16_t logical_max, uint16_t logical_per_rotation);
+
+void Input_SetAnalogRange(uint8_t index, uint8_t trigger, uint8_t release);
 
 uint16_t*Input_PtrButtons(void);
-uint16_t*Input_PtrRotaryPhysicalPosition(uint16_t index);
-uint16_t*Input_PtrRotaryLogicalPosition(uint16_t index);
-uint16_t*Input_PtrRotaryDirection(uint16_t index);
+uint16_t*Input_PtrRotaryPhysicalPosition(uint8_t index);
+uint16_t*Input_PtrRotaryLogicalPosition(uint8_t index);
+uint16_t*Input_PtrRotaryDirection(uint8_t index);
+uint16_t*Input_PtrAnalog(uint8_t index);
+uint16_t*Input_PtrAnalogDigital(void);
 
 uint16_t Output_Get(void);
 void     Output_Set(uint16_t data);

--- a/input.h
+++ b/input.h
@@ -136,7 +136,7 @@ uint16_t Input_GetAnalogDigital(void);
 
 void Input_RotaryLogicalTarget(uint8_t index, uint16_t logical_max, uint16_t logical_per_rotation);
 
-void Input_SetAnalogRange(uint8_t index, uint8_t trigger, uint8_t release);
+void Input_AnalogDigitalThresholds(uint8_t index, uint8_t trigger, uint8_t release);
 
 uint16_t*Input_PtrButtons(void);
 uint16_t*Input_PtrRotaryPhysicalPosition(uint8_t index);


### PR DESCRIPTION
The following PR provides support for analog inputs with 8 bits of resolution, through the following functions:

* `Input_RegisterAnalog(ANALOG_PIN_INDEX, ANALOG_SHOULD_INVERT)`, supplying a pin and whether to invert the incoming value.
* `Input_AnalogDigitalThresholds(index, uint8_t trigger, uint8_t release)`, supplying values to use to determine when an analog input should provide a digital `trigger` and when that trigger should be `release`d.
* `Input_GetAnalog(index)` to get the 8-bit analog value.
* `Input_GetAnalogDigital()` to get a digital representation of all analog inputs based on thresholds.